### PR TITLE
Use new Serialport isOpen boolean API

### DIFF
--- a/lib/EnttecUsbProMk2Driver.js
+++ b/lib/EnttecUsbProMk2Driver.js
@@ -82,7 +82,7 @@ export default class EnttecUsbProMk2Driver {
    * @private
    */
   awaitSerialportOpened() {
-    if (this.serialport.isOpen()) {
+    if (this.serialport.isOpen) {
       return Promise.resolve(this.serialport);
     }
 


### PR DESCRIPTION
I was getting errors about isOpen being a boolean, because apparently serialport has changed the API here