### PR TITLE
Support old and new versions of serialport

### DIFF
--- a/lib/EnttecUsbProMk2Driver.js
+++ b/lib/EnttecUsbProMk2Driver.js
@@ -82,7 +82,8 @@ export default class EnttecUsbProMk2Driver {
    * @private
    */
   awaitSerialportOpened() {
-    if (this.serialport.isOpen) {
+    const isOpen = this.serialport.isOpen;
+    if (typeof isOpen == 'function' ? isOpen() : isOpen) {
       return Promise.resolve(this.serialport);
     }
 


### PR DESCRIPTION
Instead of assuming people use newer versions of serialport, just test if it is a function and use it if needed.

Should resolve #3